### PR TITLE
Added support for IPV6 connections

### DIFF
--- a/wai-middleware-throttle.cabal
+++ b/wai-middleware-throttle.cabal
@@ -1,6 +1,6 @@
 
 name:                wai-middleware-throttle
-version:             0.2.0.1
+version:             0.2.0.2
 license:             BSD3
 license-file:        LICENSE
 author:              Christopher Reichert
@@ -33,6 +33,7 @@ library
                      , http-types
                      , stm
                      , token-bucket
+                     , hashable
 
   if impl(ghc < 7.8)
     build-depends:


### PR DESCRIPTION
Hi I saw the connections were only being throttled based on IPV4 address so in this pull request I basically only generalized it to include IPV6 support. I loosely map IPV4 address to an IPV6 address and then the IntMap takes the hash of the IPV6 address as key and stores (address, bucket) list as values. There probably won't be a lot of hash collisions so the lists will be small. I tried to change as little as possible while still adding IPV6 support. It adds an additional dependancy on hashable but only uses the hash functions which is available in all versions of the library.
