### PR TITLE
Fully support SockAddr

### DIFF
--- a/Network/Wai/Middleware/Throttle.hs
+++ b/Network/Wai/Middleware/Throttle.hs
@@ -71,13 +71,13 @@ instance Eq Address where
   Address (SockAddrInet _ a)      == Address (SockAddrInet _ b)      = a == b
   Address (SockAddrInet6 _ _ a _) == Address (SockAddrInet6 _ _ b _) = a == b
   Address (SockAddrUnix a)        == Address (SockAddrUnix b)        = a == b
-  a == b = False -- not same so cant be equal
+  _ == _ = False -- not same constructor so cant be equal
 
 instance Ord Address where
   Address (SockAddrInet _ a)      <= Address (SockAddrInet _ b)      = a <= b
   Address (SockAddrInet6 _ _ a _) <= Address (SockAddrInet6 _ _ b _) = a <= b
   Address (SockAddrUnix a)        <= Address (SockAddrUnix b)        = a <= b
-  a <= b = a <= b -- not same so use builtin ordering
+  Address a <= Address b = a <= b -- not same constructor so use builtin ordering
 
 -- | A 'HashMap' mapping the remote IP address to a 'TokenBucket'
 data ThrottleState = ThrottleState !(IM.IntMap [(Address,TokenBucket)])

--- a/wai-middleware-throttle.cabal
+++ b/wai-middleware-throttle.cabal
@@ -29,11 +29,15 @@ library
                      , wai                   >= 3.0
                      , containers
                      , transformers
-                     , network               < 2.6.1
+                     , network               >= 2.1
                      , http-types
                      , stm
                      , token-bucket
                      , hashable              >= 1.2
+
+  other-extensions: CPP
+                    OverloadedStrings
+                    RecordWildCards
 
   if impl(ghc < 7.8)
     build-depends:

--- a/wai-middleware-throttle.cabal
+++ b/wai-middleware-throttle.cabal
@@ -29,7 +29,7 @@ library
                      , wai                   >= 3.0
                      , containers
                      , transformers
-                     , network               < 3.6.1
+                     , network               < 2.6.1
                      , http-types
                      , stm
                      , token-bucket

--- a/wai-middleware-throttle.cabal
+++ b/wai-middleware-throttle.cabal
@@ -29,11 +29,11 @@ library
                      , wai                   >= 3.0
                      , containers
                      , transformers
-                     , network
+                     , network               < 3.6.1
                      , http-types
                      , stm
                      , token-bucket
-                     , hashable
+                     , hashable              >= 1.2
 
   if impl(ghc < 7.8)
     build-depends:


### PR DESCRIPTION
Hi I made the change to fully support SockAddr using a newtype wrapper, it did require that I restrict the versions of hashable and network packages though. The network package from 2.6.1 adds an extra "can" constructor so that is the reason for the upper limit and the instance for hashable changed in 1.2 so that is the reason for the lower limit.
