### PR TITLE
Export Network.Wai.Middleware.Throttle.Address

### DIFF
--- a/Network/Wai/Middleware/Throttle.hs
+++ b/Network/Wai/Middleware/Throttle.hs
@@ -39,6 +39,7 @@ module Network.Wai.Middleware.Throttle (
     , ThrottleSettings(..)
     , defaultThrottleSettings
 
+    , Address(..)
     , RequestHashable(..)
     ) where
 

--- a/wai-middleware-throttle.cabal
+++ b/wai-middleware-throttle.cabal
@@ -1,5 +1,5 @@
 name:                wai-middleware-throttle
-version:             0.2.2.0
+version:             0.2.2.1
 license:             BSD3
 license-file:        LICENSE
 author:              Christopher Reichert


### PR DESCRIPTION
Adding this type to the export list allows custom throttlers to be built
using a composition of the remoteHost address and other request characteristics
without having to reimplement Hashable for SockAddr.