### PR TITLE
Allow network-3.2

### DIFF
--- a/wai-middleware-throttle.cabal
+++ b/wai-middleware-throttle.cabal
@@ -34,7 +34,7 @@ library
                      , hashable              >= 1.2
                      , http-types
                      , mtl
-                     , network               >= 2.4.2 && <3.2
+                     , network               >= 2.4.2 && <3.3
                      , safe-exceptions
                      , stm
                      , text


### PR DESCRIPTION
Tested using

    cabal build -w ghc-9.10.1 -c 'network>=3.2' -c 'hashable>=1.5' '--allow-newer=*:hashable'

Addresses

* https://github.com/commercialhaskell/stackage/issues/7381
